### PR TITLE
Fix glitch in non-region landmasses and tweak plot boundaries

### DIFF
--- a/R/Map_Functions.R
+++ b/R/Map_Functions.R
@@ -106,10 +106,16 @@ addRegionID <- function(datatable, lookupfile = lut.rgn32, provincefile = NULL, 
 
     ## Regions that weren't in the original table will show as NA.
     ## Zero them out and give them a sensible unit.
-    finaltable$Units[is.na(finaltable$Units)] <- finaltable$Units[1]  # units will usually be all the same
-    finaltable[is.na(finaltable)] <- 0  # set all remaining NA values to zero.
+    unit <- finaltable$Units[!is.na(finaltable$Units)][1]  # pick the first available unit value; they should all be the same
+    finaltable$Units[is.na(finaltable$Units)] <- unit
+    ## set column name for id column
     colnames(finaltable)[ncol(finaltable)] <- "id"
-    finaltable$id <- as.character(finaltable$id)
+
+    ## find NA values
+    na.vals <- is.na(finaltable)
+    na.vals[finaltable$id==0,] <- FALSE    # exclude non-regions; they should stay NA
+    finaltable[na.vals] <- 0
+    finaltable$id <- as.character(finaltable$id)  # other functions are expecting id to be a char
 
     # Add null vector row to end to account for GCAM region 0
     nullvec <- rep(NA, ncol(finaltable))

--- a/R/diag_header.R
+++ b/R/diag_header.R
@@ -283,7 +283,7 @@ EXTENT_AFRICA <- c(-20,60,-40,40)
 #' This vector can be used as the \code{extent} argument to
 #' \code{\link{plot_GCAM}}.
 #' @export
-EXTENT_LA <- c(-120,-30,-60,40)
+EXTENT_LA <- c(-120,-30,-60,32)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
* Leave values for unassigned land masses as NA in `addRegionID()`
* Trim the boundaries of the LAC projection slightly to emphasize the region of interest.